### PR TITLE
Better name for localstorage key for saving filter state.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,5 +24,5 @@ run(main, {
   HTTP: makeHTTPDriver({autoSubscribe: true}),
   Popup: popupDriver,
   Route: hashRouteDriver,
-  LocalStorage: makeLocalStorageDriver('power-ui-test'),
+  LocalStorage: makeLocalStorageDriver('power-ui-filters'),
 });


### PR DESCRIPTION
Change the localstorage key name from `power-ui-test` to `power-ui-filters`.