### PR TITLE
Adds a possibility for creating code coverage reports

### DIFF
--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,0 +1,27 @@
+verbose: false
+instrumentation:
+    root: "src/"
+    default-excludes: true
+    excludes: ['**/static/**']
+    embed-source: false
+    variable: __coverage__
+    compact: true
+    preserve-comments: false
+    complete-copy: false
+    save-baseline: false
+    baseline-file: ./coverage/coverage-baseline.json
+    include-all-sources: true
+reporting:
+    print: summary
+    reports:
+        - lcov
+    dir: ./coverage
+    watermarks:
+        statements: [50, 90]
+        lines: [50, 90]
+        functions: [50, 90]
+        branches: [50, 90]
+hooks:
+    hook-run-in-context: false
+    post-require-hook: null
+

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "lint": "eslint src/",
     "mocha": "mocha --compilers js:babel/register,scss:power-ui/test-utils/mocha-scss-compiler.js src/**/test.js",
-    "cover": "babel-node ./node_modules/.bin/isparta cover ./node_modules/.bin/_mocha -- --compilers scss:power-ui/test-utils/mocha-scss-compiler.js src/**/test.js",
+    "cover": "isparta cover _mocha -- --compilers scss:power-ui/test-utils/mocha-scss-compiler.js src/**/test.js",
     "test": "npm run lint && npm run mocha",
     "watch:lint": "esw -w src",
     "watch:static": "cpx \"src/static/**/*\" dist --watch",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "lint": "eslint src/",
     "mocha": "mocha --compilers js:babel/register,scss:power-ui/test-utils/mocha-scss-compiler.js src/**/test.js",
+    "cover": "babel-node ./node_modules/.bin/isparta cover ./node_modules/.bin/_mocha -- --compilers scss:power-ui/test-utils/mocha-scss-compiler.js src/**/test.js",
     "test": "npm run lint && npm run mocha",
     "watch:lint": "esw -w src",
     "watch:static": "cpx \"src/static/**/*\" dist --watch",
@@ -50,6 +51,7 @@
     "eslint": "^1.1.0",
     "eslint-watch": "^1.2.5",
     "extract-text-webpack-plugin": "^0.8.1",
+    "isparta": "3.0.2",
     "mocha": "^2.3.2",
     "node-sass": "^3.3.2",
     "postcss-loader": "^0.4.3",


### PR DESCRIPTION
run `npm run cover` to create coverage report to `coverage/` directory. 

The html version of the report can be found from path `coverage/lcov-report/index.html`