### PR TITLE
Powerhead page show all

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "npm run lint && npm run mocha",
     "watch:lint": "esw -w src",
     "watch:static": "cpx \"src/static/**/*\" dist --watch",
+    "watch:test": "mocha -w --compilers js:babel/register,scss:power-ui/test-utils/mocha-scss-compiler.js src/**/test.js",
     "make-power-ui-symlink": "cd node_modules && ln -nsf ../src power-ui",
     "prewatch": "npm run make-power-ui-symlink",
     "postinstall": "npm run make-power-ui-symlink",
@@ -58,6 +59,7 @@
     "sass-loader": "^2.0.1",
     "style-loader": "^0.12.3",
     "url-loader": "^0.5.6",
+    "vtree-select": "^1.1.1",
     "webpack": "^1.9.10",
     "webpack-dev-server": "^1.9.0"
   }

--- a/src/components/pages/PowerheadPage/http.js
+++ b/src/components/pages/PowerheadPage/http.js
@@ -41,7 +41,7 @@ function timeRange$(props$) {
 function PowerheadPageHTTP(sources) {
   const POWERHEAD_URL = `${API_PATH}/powerhead/`;
 
-  const request$ = timeRange$(sources.props$)
+  const request$ = timeRange$(sources.props$.first())
     .map(timeRangeToUrlParams)
     .map(timeRangeParams => POWERHEAD_URL + `?${timeRangeParams}`)
     .map(urlToRequestObjectWithHeaders);

--- a/src/components/pages/PowerheadPage/model.js
+++ b/src/components/pages/PowerheadPage/model.js
@@ -67,7 +67,15 @@ function makeFilterByLocationFn$(selectedLocation$) {
         || location === report.country
         || location === report.site
       );
-      return {...oldState, reports: newReports};
+
+      return {
+        ...oldState,
+        reports: newReports,
+        filters: {
+          ...oldState.filters,
+          location: location,
+        },
+      };
     })
     .startWith(_.identity); // identity means "allow anything"
 }

--- a/src/components/pages/PowerheadPage/reportUtils.js
+++ b/src/components/pages/PowerheadPage/reportUtils.js
@@ -1,0 +1,88 @@
+/**
+ * This file is part of power-ui, originally developed by Futurice Oy.
+ *
+ * power-ui is licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import _ from 'lodash';
+
+function augmentReportsWithFinancials(reports) {
+  return reports.map(report => {
+    // Array with the sum of all financials stats, one entry per month
+    const financialsSum = _.zipWith(
+      report.value_creation, report.overrun,
+      _.add
+    );
+    const costs = _.zipWith(
+      report.fte, report.ext_fte,
+      _.add
+    ).map(totalFte => totalFte * report.expenses_per_fte_month);
+    // Among all months, highest sum of all financials for this tribe report:
+    const maxFinancialsVal = Math.max(...costs, ...financialsSum);
+    return {...report, financialsSum, costs, maxFinancialsVal};
+  });
+}
+
+function augmentReportsWithMetadata(reports) {
+  const reportsWithRespectiveTotals = augmentReportsWithFinancials(reports);
+  const maxFinancialsValPerReport = reportsWithRespectiveTotals
+    .map(report => report.maxFinancialsVal);
+  const companyWideMaxFinancialsVal = Math.max(...maxFinancialsValPerReport);
+  return reportsWithRespectiveTotals.map(report => {
+    return {...report, companyWideMaxFinancialsVal};
+  });
+}
+
+// Combines an array of n reports into an array of 1 report.
+function combineReports(reports) {
+  if (reports.length === 0) {
+    return [];
+  }
+
+  const augmentedReports = augmentReportsWithFinancials(reports);
+
+  const monthCount = reports[0].months.length;
+  const initialReport = {
+    months: reports[0].months,
+    business_days: reports[0].business_days,
+    value_creation: _.fill(Array(monthCount), 0),
+    orderbook: _.fill(Array(monthCount), 0),
+    overrun: _.fill(Array(monthCount), 0),
+    fte: _.fill(Array(monthCount), 0),
+    bench: _.fill(Array(monthCount), 0),
+    ext_fte: _.fill(Array(monthCount), 0),
+    costs: _.fill(Array(monthCount), 0),
+    financialsSum: _.fill(Array(monthCount), 0),
+    maxFinancialsVal: _.sum(augmentedReports.map(report => report.maxFinancialsVal)),
+    companyWideMaxFinancialsVal: _.sum(augmentedReports
+      .map(report => report.maxFinancialsVal)
+    ),
+    name: 'All',
+    expenses_per_fte_month: reports.map(report => report.expenses_per_fte_month),
+  };
+
+  const combined = augmentedReports.reduce((combinedReport, tribeReport) => {
+    const attributesToCombine = [
+      'value_creation', 'overrun', 'fte', 'bench', 'ext_fte', 'costs', 'financialsSum',
+    ];
+    attributesToCombine.forEach(attr => {
+      combinedReport[attr] = _.zipWith(combinedReport[attr], tribeReport[attr], _.add);
+    });
+
+    return combinedReport;
+  }, initialReport);
+
+  return [combined];
+}
+
+export default {augmentReportsWithMetadata, combineReports};

--- a/src/components/pages/PowerheadPage/styles.scss
+++ b/src/components/pages/PowerheadPage/styles.scss
@@ -236,6 +236,39 @@ $peopleBoxSize: 8px;
   background-color: $colorGrayLight;
 }
 
+
+.monthGraphPeopleBoxListSmall {
+  @extend .monthGraphPeopleBoxList;
+  width: (5 * $peopleBoxSize);
+}
+
+.monthGraphPeopleChunkSmall {
+  @extend .monthGraphPeopleChunk;
+  width: (5 * $peopleBoxSize);
+}
+
+.monthGraphPeopleBoxSmall {
+  @extend .monthGraphPeopleBox;
+  width: $peopleBoxSize / 2;
+  height: $peopleBoxSize / 2;
+}
+
+.monthGraphPeopleBoxExternalSmall {
+  @extend .monthGraphPeopleBoxSmall;
+  background-color: $colorPurple;
+}
+
+.monthGraphPeopleBoxBookedSmall {
+  @extend .monthGraphPeopleBoxSmall;
+  background-color: $colorGreenLight;
+}
+
+.monthGraphPeopleBoxBenchSmall {
+  @extend .monthGraphPeopleBoxSmall;
+  background-color: $colorGrayLight;
+}
+
+
 .monthGraphLabel {
   border-top: 2px solid $colorBlack;
   text-align: center;

--- a/src/components/pages/PowerheadPage/test.js
+++ b/src/components/pages/PowerheadPage/test.js
@@ -1,0 +1,193 @@
+/**
+ * This file is part of power-ui, originally developed by Futurice Oy.
+ *
+ * power-ui is licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+/* global describe, it */
+import chai from 'chai';
+const expect = chai.expect;
+chai.use(require('chai-virtual-dom'));
+import {h, mockDOMResponse} from '@cycle/dom';
+import {Rx} from '@cycle/core';
+import {API_PATH} from 'power-ui/conf';
+import PowerheadPage from './index';
+import PowerheadPageHTTP from './http';
+import moment from "moment";
+import {replicateStream} from 'power-ui/utils';
+import select from 'vtree-select';
+
+const mockData = {"count":2,"next":null,"previous":null,"results":[{"id":1,"months":[{"September":"2015-09-01"},{"October":"2015-10-01"},{"November":"2015-11-01"},{"December":"2015-12-01"}],"value_creation":[1000,1000,1000,1000],"orderbook":[10000,10000,10000,10000],"overrun":[5,5,5,5],"business_days":[22,22,21,21],"fte":[10,10,10,10],"bench":[2,2,2,2],"ext_fte":[1.0,1.0,1.0,1.0],"name":"Test-org-1","expenses_per_fte_month":"4000.00","days_per_week":5,"hours_per_day":"7.50","target_hourly_rate":"10.00","country":"FI","holiday_calendar":1,"site":1},{"id":5,"months":[{"September":"2015-09-01"},{"October":"2015-10-01"},{"November":"2015-11-01"},{"December":"2015-12-01"}],"value_creation":[2000,2000,2000,2000],"orderbook":[20000,20000,20000,20000],"overrun":[10,10,10,10],"business_days":[22,22,21,21],"fte":[20,20,20,20],"bench":[3,3,3,3],"ext_fte":[2.0,2.0,2.0,2.0],"name":"Test-org-2","expenses_per_fte_month":"4000.00","days_per_week":5,"hours_per_day":"8.00","target_hourly_rate":"10.00","country":"DE","holiday_calendar":2,"site":3}]};
+
+
+function createPowerheadPageObject(vtree) {
+
+	const reportCount = select(".tribe_report")(vtree).length;
+
+	const internals = select(".ints")(vtree)
+		.map(el => el.children[1].children[0].text);
+
+	const externals = select(".exts")(vtree)
+		.map(el => el.children[1].children[0].text);
+
+	const bench = select(".bench")(vtree)
+		.map(el => el.children[1].children[0].text);
+
+	const booked = select(".booked")(vtree)
+		.map(el => el.children[1].children[0].text);
+
+	const confirmed_revenue = select(".confirmed_revenue")(vtree)
+		.map(el => el.children[2].children[0].text);
+
+	const overruns = select(".overruns")(vtree)
+		.map(el => el.children[2].children[0].text);
+
+
+
+
+	return { reportCount, internals, externals, bench, booked, confirmed_revenue, overruns };
+}
+
+
+function mockHTTPDriver() {
+
+	return function handleHTTPRequest(request$) {
+		const POWERHEAD_URL = `${API_PATH}/powerhead/`;
+
+		return request$.map(request => {
+
+			return {
+				request: request$,
+		  		body: []
+		  	};
+		});
+	}
+}
+
+describe('PowerheadPageHTTP', () => {
+
+  it('should be a function', () => {
+	expect(PowerheadPageHTTP).to.be.a('function');
+  });
+
+  it('calling the HTTP should return a request with url', (done) => {
+	const props$ = Rx.Observable.just({});
+	const HTTPSource = Rx.Observable.empty();
+	const {request$, response$} = PowerheadPageHTTP({props$, HTTP: HTTPSource});
+	
+	request$.subscribe(req => {
+
+		expect(req.url).to.equal('http://localhost:8000/api/v1/powerhead/?range_start=2015-09-01&range_end=2015-09-30');
+		done();
+	});
+  });
+
+  it('should map the responses to body.results', (done) => {
+	const props$ = Rx.Observable.just({});
+	const HTTPSource = new Rx.ReplaySubject(1);
+	const {request$, response$} = PowerheadPageHTTP({props$, HTTP: HTTPSource});
+	
+	response$.subscribe(response => {
+	
+		expect(response).to.equal("test");
+		done();
+
+	});
+
+	request$.map(req => {
+		
+		var response$ = Rx.Observable.just({
+			request: req,
+			body: { results: "test" }
+		});
+		response$.request = req;
+		return response$;
+
+	}).subscribe(HTTPSource.asObserver());
+
+
+  });
+
+});
+
+
+describe('PowerheadPage', () => {
+  it('should be a function', () => {
+    expect(PowerheadPage).to.be.a('function');
+  });
+
+  describe('using filter "all"', () => {
+
+  	const props$ = Rx.Observable.just({
+      location: 'all',
+      lookaheadLength: 1,
+      reportLength: 2
+    });
+
+  	const HTTPsource$ = new Rx.ReplaySubject(1);
+
+    const DOMSource = mockDOMResponse();
+
+    const powerHeadPage = PowerheadPage({
+		DOM: DOMSource, 
+		HTTP: HTTPsource$,
+		props$
+	});
+
+    const request$ = powerHeadPage.HTTP;
+
+	request$.map(request => {
+		const mockedResponse$ = Rx.Observable.just({
+	  		body: mockData
+		});
+		mockedResponse$.request = request;
+		return mockedResponse$;
+	})
+	.subscribe(HTTPsource$.asObserver());
+
+    powerHeadPage.DOM.elementAt(0).subscribe(vtree => {
+ 	
+ 		const page = createPowerheadPageObject(vtree);
+
+ 		it('should have a single report', () => {
+ 			expect(page.reportCount).to.equal(1);
+ 		});
+
+ 		it('should have a sum of internals from all reports, for each month', () => {
+ 			expect(page.internals).to.eql(['30','30','30']);
+ 		});
+
+ 		it('should have a sum of bench from all reports, for each month', () => {
+ 			expect(page.bench).to.eql(['5','5','5']);
+ 		});
+
+ 		it('should have a sum of booked from all reports, for each month', () => {
+ 			expect(page.booked).to.eql(['25','25','25']);
+ 		});
+
+ 		it('should have a sum of externals from all reports, for each month', () => {
+ 			expect(page.externals).to.eql(['3','3','3']);
+ 		});
+
+		it('should have a sum revenue from all reports, for each month', () => {
+ 			expect(page.confirmed_revenue).to.eql(['3 000', '3 000', '3 000']);
+ 		});
+
+ 		it('should have a sum overruns from all reports, for each month', () => {
+ 			expect(page.overruns).to.eql(['15','15','15']);
+ 		});
+
+    });
+
+
+  });
+});

--- a/src/components/pages/PowerheadPage/test.js
+++ b/src/components/pages/PowerheadPage/test.js
@@ -13,154 +13,143 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-/* global describe, it */
+/* global describe, it, require */
+/* eslint max-nested-callbacks:0, no-unused-expressions:0 */
 import chai from 'chai';
 const expect = chai.expect;
 chai.use(require('chai-virtual-dom'));
-import {h, mockDOMResponse} from '@cycle/dom';
+import {mockDOMResponse} from '@cycle/dom';
 import {Rx} from '@cycle/core';
 import {API_PATH} from 'power-ui/conf';
 import PowerheadPage from './index';
 import PowerheadPageHTTP from './http';
-import moment from "moment";
-import {replicateStream} from 'power-ui/utils';
 import select from 'vtree-select';
 import {combineReports, augmentReportsWithMetadata} from './reportUtils';
 import _ from 'lodash';
-
-const mockData = {"count":2,"next":null,"previous":null,"results":[{"id":1,"months":[{"September":"2015-09-01"},{"October":"2015-10-01"},{"November":"2015-11-01"},{"December":"2015-12-01"}],"value_creation":[1000,1000,1000,1000],"orderbook":[10000,10000,10000,10000],"overrun":[5,5,5,5],"business_days":[22,22,21,21],"fte":[10,10,10,10],"bench":[2,2,2,2],"ext_fte":[1.0,1.0,1.0,1.0],"name":"Test-org-1","expenses_per_fte_month":"5000.00","days_per_week":5,"hours_per_day":"7.50","target_hourly_rate":"10.00","country":"FI","holiday_calendar":1,"site":1},{"id":5,"months":[{"September":"2015-09-01"},{"October":"2015-10-01"},{"November":"2015-11-01"},{"December":"2015-12-01"}],"value_creation":[2000,2000,2000,2000],"orderbook":[20000,20000,20000,20000],"overrun":[10,10,10,10],"business_days":[22,22,21,21],"fte":[20,20,20,20],"bench":[3,3,3,3],"ext_fte":[2.0,2.0,2.0,2.0],"name":"Test-org-2","expenses_per_fte_month":"4000.00","days_per_week":5,"hours_per_day":"8.00","target_hourly_rate":"10.00","country":"DE","holiday_calendar":2,"site":3}]};
+import {mockPowerheadResponse} from './testdata';
 
 function createPowerheadPageObject(vtree) {
+  const reportCount = select('.tribe_report')(vtree).length;
 
-	const reportCount = select(".tribe_report")(vtree).length;
+  const internals = select('.ints')(vtree)
+    .map(el => el.children[1].children[0].text);
 
-	const internals = select(".ints")(vtree)
-		.map(el => el.children[1].children[0].text);
+  const externals = select('.exts')(vtree)
+    .map(el => el.children[1].children[0].text);
 
-	const externals = select(".exts")(vtree)
-		.map(el => el.children[1].children[0].text);
+  const bench = select('.bench')(vtree)
+    .map(el => el.children[1].children[0].text);
 
-	const bench = select(".bench")(vtree)
-		.map(el => el.children[1].children[0].text);
+  const booked = select('.booked')(vtree)
+    .map(el => el.children[1].children[0].text);
 
-	const booked = select(".booked")(vtree)
-		.map(el => el.children[1].children[0].text);
+  const confirmed_revenue = select('.confirmed_revenue')(vtree)
+    .map(el => el.children[2].children[0].text);
 
-	const confirmed_revenue = select(".confirmed_revenue")(vtree)
-		.map(el => el.children[2].children[0].text);
+  const overruns = select('.overruns')(vtree)
+    .map(el => el.children[2].children[0].text);
 
-	const overruns = select(".overruns")(vtree)
-		.map(el => el.children[2].children[0].text);
-
-	return { reportCount, internals, externals, bench, booked, confirmed_revenue, overruns };
+  return {
+    reportCount, internals, externals, bench, booked, confirmed_revenue, overruns,
+  };
 }
 
 describe('augmentReportsWithMetadata', () => {
+  it('should be a function', () => {
+    expect(augmentReportsWithMetadata).to.be.a('function');
+  });
 
-	it('should be a function', () => {
-		expect(augmentReportsWithMetadata).to.be.a('function');
-	});
+  it('should add costs to reports', () => {
+    const augmentedReports = augmentReportsWithMetadata(mockPowerheadResponse.results);
+    expect(augmentedReports[0].costs).to.eql([55000, 55000, 55000, 55000]);
+    expect(augmentedReports[1].costs).to.eql([88000, 88000, 88000, 88000]);
+  });
 
-	it('should add costs to reports', () => {
-		const augmentedReports = augmentReportsWithMetadata(mockData.results);
-		expect(augmentedReports[0].costs).to.eql([55000, 55000, 55000, 55000]);
-		expect(augmentedReports[1].costs).to.eql([88000, 88000, 88000, 88000]);
-	});
+  it('should add financialsSum to reports', () => {
+    const augmentedReports = augmentReportsWithMetadata(mockPowerheadResponse.results);
+    expect(augmentedReports[0].financialsSum).to.eql([1005, 1005, 1005, 1005]);
+    expect(augmentedReports[1].financialsSum).to.eql([2010, 2010, 2010, 2010]);
+  });
 
-	it('should add financialsSum to reports', () => {
-		const augmentedReports = augmentReportsWithMetadata(mockData.results);
-		expect(augmentedReports[0].financialsSum).to.eql([ 1005, 1005, 1005, 1005 ]);
-		expect(augmentedReports[1].financialsSum).to.eql([ 2010, 2010, 2010, 2010, ]);
-	});
-	
-	it('should add maxFinancialsVal to reports', () => {
-		const augmentedReports = augmentReportsWithMetadata(mockData.results);
-		expect(augmentedReports[0].maxFinancialsVal).to.eql(55000);
-		expect(augmentedReports[1].maxFinancialsVal).to.eql(88000);
-	});
+  it('should add maxFinancialsVal to reports', () => {
+    const augmentedReports = augmentReportsWithMetadata(mockPowerheadResponse.results);
+    expect(augmentedReports[0].maxFinancialsVal).to.eql(55000);
+    expect(augmentedReports[1].maxFinancialsVal).to.eql(88000);
+  });
 
-	it('should add companyWideMaxFinancialsVal to reports', () => {
-		const augmentedReports = augmentReportsWithMetadata(mockData.results);
-		expect(augmentedReports[0].companyWideMaxFinancialsVal).to.eql(88000);
-		expect(augmentedReports[1].companyWideMaxFinancialsVal).to.eql(88000);
-	});
+  it('should add companyWideMaxFinancialsVal to reports', () => {
+    const augmentedReports = augmentReportsWithMetadata(mockPowerheadResponse.results);
+    expect(augmentedReports[0].companyWideMaxFinancialsVal).to.eql(88000);
+    expect(augmentedReports[1].companyWideMaxFinancialsVal).to.eql(88000);
+  });
 });
 
 describe('combineReports', () => {
+  it('should be a function', () => {
+    expect(combineReports).to.be.a('function');
+  });
 
-	it('should be a function', () => {
-		expect(combineReports).to.be.a('function');
-	});
+  it('should combine array of n reports to array of 1 report', () => {
+    const reports = mockPowerheadResponse.results;
+    const combinedReportArray = combineReports(reports);
+    expect(combinedReportArray).to.have.length.of(1);
+  });
 
-	it('should combine array of n reports to array of 1 report', () => {
-		const reports = mockData.results;
-		const combinedReportArray = combineReports(reports);
-		expect(combinedReportArray).to.have.length.of(1);
-	});
+  describe('combined report', () => {
+    const combinedArray = combineReports(mockPowerheadResponse.results);
+    const combined = combinedArray[0];
 
-	describe('combined report', () => {
-		const combinedArray = combineReports(mockData.results);
-		const combined = combinedArray[0];
-		
-		it('should have costs calculated correctly', () => {
-			expect(combined.costs).to.eql([143000, 143000, 143000, 143000]);
-		});
-		it('should have financialsSum calculated correctly', () => {
-			expect(combined.financialsSum).to.eql([3015, 3015, 3015, 3015]);
-		});
-		it('should have maxFinancialsVal calculated correctly', () => {
-			expect(combined.maxFinancialsVal).to.eql(143000);
-		});
-		it('should have companyWideMaxFinancialsVal calculated correctly', () => {
-			expect(combined.companyWideMaxFinancialsVal).to.eql(143000);
-		});
-	})
+    it('should have costs calculated correctly', () => {
+      expect(combined.costs).to.eql([143000, 143000, 143000, 143000]);
+    });
+    it('should have financialsSum calculated correctly', () => {
+      expect(combined.financialsSum).to.eql([3015, 3015, 3015, 3015]);
+    });
+    it('should have maxFinancialsVal calculated correctly', () => {
+      expect(combined.maxFinancialsVal).to.eql(143000);
+    });
+    it('should have companyWideMaxFinancialsVal calculated correctly', () => {
+      expect(combined.companyWideMaxFinancialsVal).to.eql(143000);
+    });
+  });
 });
 
 describe('PowerheadPageHTTP', () => {
-
   it('should be a function', () => {
-	expect(PowerheadPageHTTP).to.be.a('function');
+    expect(PowerheadPageHTTP).to.be.a('function');
   });
 
   it('calling the HTTP should return a request with url', (done) => {
-	const props$ = Rx.Observable.just({});
-	const HTTPSource = Rx.Observable.empty();
-	const {request$, response$} = PowerheadPageHTTP({props$, HTTP: HTTPSource});
-	
-	request$.subscribe(req => {
+    const props$ = Rx.Observable.just({});
+    const HTTPSource = Rx.Observable.empty();
+    const {request$} = PowerheadPageHTTP({props$, HTTP: HTTPSource});
 
-		expect( _.startsWith(req.url, `${API_PATH}/powerhead/`) ).to.be.true;
-		done();
-	});
+    request$.subscribe(req => {
+      expect(_.startsWith(req.url, `${API_PATH}/powerhead/`)).to.be.true;
+      done();
+    });
   });
 
   it('should map the responses to body.results', (done) => {
-	const props$ = Rx.Observable.just({});
-	const HTTPSource = new Rx.ReplaySubject(1);
-	const {request$, response$} = PowerheadPageHTTP({props$, HTTP: HTTPSource});
-	
-	response$.subscribe(response => {
-		expect(response).to.equal("test");
-		done();
-	});
+    const props$ = Rx.Observable.just({});
+    const HTTPSource = new Rx.ReplaySubject(1);
+    const {request$, response$} = PowerheadPageHTTP({props$, HTTP: HTTPSource});
 
-	request$.map(req => {
-		
-		var response$ = Rx.Observable.just({
-			request: req,
-			body: { results: "test" }
-		});
-		response$.request = req;
-		return response$;
+    response$.subscribe(response => {
+      expect(response).to.equal('test');
+      done();
+    });
 
-	}).subscribe(HTTPSource.asObserver());
-
-
+    request$.map(req => {
+      const res$ = Rx.Observable.just({
+        request: req,
+        body: {results: 'test'},
+      });
+      res$.request = req;
+      return res$;
+    }).subscribe(HTTPSource.asObserver());
   });
-
 });
-
 
 describe('PowerheadPage', () => {
   it('should be a function', () => {
@@ -168,68 +157,62 @@ describe('PowerheadPage', () => {
   });
 
   describe('using filter "all"', () => {
-
-  	const props$ = Rx.Observable.just({
+    const props$ = Rx.Observable.just({
       location: 'all',
       lookaheadLength: 1,
-      reportLength: 2
+      reportLength: 2,
     });
 
-  	const HTTPsource$ = new Rx.ReplaySubject(1);
+    const HTTPsource$ = new Rx.ReplaySubject(1);
 
     const DOMSource = mockDOMResponse();
 
     const powerHeadPage = PowerheadPage({
-		DOM: DOMSource, 
-		HTTP: HTTPsource$,
-		props$
-	});
+      DOM: DOMSource,
+      HTTP: HTTPsource$,
+      props$,
+    });
 
     const request$ = powerHeadPage.HTTP;
 
-	request$.map(request => {
-		const mockedResponse$ = Rx.Observable.just({
-	  		body: mockData
-		});
-		mockedResponse$.request = request;
-		return mockedResponse$;
-	})
-	.subscribe(HTTPsource$.asObserver());
+    request$.map(request => {
+      const mockedResponse$ = Rx.Observable.just({
+        body: mockPowerheadResponse,
+      });
+      mockedResponse$.request = request;
+      return mockedResponse$;
+    }).subscribe(HTTPsource$.asObserver());
 
     powerHeadPage.DOM.elementAt(0).subscribe(vtree => {
- 	
- 		const page = createPowerheadPageObject(vtree);
+      const page = createPowerheadPageObject(vtree);
 
- 		it('should have a single report', () => {
- 			expect(page.reportCount).to.equal(1);
- 		});
+      it('should have a single report', () => {
+        expect(page.reportCount).to.equal(1);
+      });
 
- 		it('should have a sum of internals from all reports, for each month', () => {
- 			expect(page.internals).to.eql(['30','30','30']);
- 		});
+      it('should have a sum of internals from all reports, for each month', () => {
+        expect(page.internals).to.eql(['30','30','30']);
+      });
 
- 		it('should have a sum of bench from all reports, for each month', () => {
- 			expect(page.bench).to.eql(['5','5','5']);
- 		});
+      it('should have a sum of bench from all reports, for each month', () => {
+        expect(page.bench).to.eql(['5','5','5']);
+      });
 
- 		it('should have a sum of booked from all reports, for each month', () => {
- 			expect(page.booked).to.eql(['25','25','25']);
- 		});
+      it('should have a sum of booked from all reports, for each month', () => {
+        expect(page.booked).to.eql(['25','25','25']);
+      });
 
- 		it('should have a sum of externals from all reports, for each month', () => {
- 			expect(page.externals).to.eql(['3','3','3']);
- 		});
+      it('should have a sum of externals from all reports, for each month', () => {
+        expect(page.externals).to.eql(['3','3','3']);
+      });
 
-		it('should have a sum revenue from all reports, for each month', () => {
- 			expect(page.confirmed_revenue).to.eql(['3 000', '3 000', '3 000']);
- 		});
+      it('should have a sum revenue from all reports, for each month', () => {
+        expect(page.confirmed_revenue).to.eql(['3 000', '3 000', '3 000']);
+      });
 
- 		it('should have a sum overruns from all reports, for each month', () => {
- 			expect(page.overruns).to.eql(['15','15','15']);
- 		});
-
+      it('should have a sum overruns from all reports, for each month', () => {
+        expect(page.overruns).to.eql(['15','15','15']);
+      });
     });
-
-
   });
 });

--- a/src/components/pages/PowerheadPage/testdata.js
+++ b/src/components/pages/PowerheadPage/testdata.js
@@ -1,3 +1,4 @@
+/* eslint quotes: 0, comma-dangle:0*/
 const mockPowerheadResponse = {
   "count": 2,
   "next": null,

--- a/src/components/pages/PowerheadPage/testdata.js
+++ b/src/components/pages/PowerheadPage/testdata.js
@@ -1,0 +1,144 @@
+const mockPowerheadResponse = {
+  "count": 2,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": 1,
+      "months": [
+        {
+          "September": "2015-09-01"
+        },
+        {
+          "October": "2015-10-01"
+        },
+        {
+          "November": "2015-11-01"
+        },
+        {
+          "December": "2015-12-01"
+        }
+      ],
+      "value_creation": [
+        1000,
+        1000,
+        1000,
+        1000
+      ],
+      "orderbook": [
+        10000,
+        10000,
+        10000,
+        10000
+      ],
+      "overrun": [
+        5,
+        5,
+        5,
+        5
+      ],
+      "business_days": [
+        22,
+        22,
+        21,
+        21
+      ],
+      "fte": [
+        10,
+        10,
+        10,
+        10
+      ],
+      "bench": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "ext_fte": [
+        1.0,
+        1.0,
+        1.0,
+        1.0
+      ],
+      "name": "Test-org-1",
+      "expenses_per_fte_month": "5000.00",
+      "days_per_week": 5,
+      "hours_per_day": "7.50",
+      "target_hourly_rate": "10.00",
+      "country": "FI",
+      "holiday_calendar": 1,
+      "site": 1
+    },
+    {
+      "id": 5,
+      "months": [
+        {
+          "September": "2015-09-01"
+        },
+        {
+          "October": "2015-10-01"
+        },
+        {
+          "November": "2015-11-01"
+        },
+        {
+          "December": "2015-12-01"
+        }
+      ],
+      "value_creation": [
+        2000,
+        2000,
+        2000,
+        2000
+      ],
+      "orderbook": [
+        20000,
+        20000,
+        20000,
+        20000
+      ],
+      "overrun": [
+        10,
+        10,
+        10,
+        10
+      ],
+      "business_days": [
+        22,
+        22,
+        21,
+        21
+      ],
+      "fte": [
+        20,
+        20,
+        20,
+        20
+      ],
+      "bench": [
+        3,
+        3,
+        3,
+        3
+      ],
+      "ext_fte": [
+        2.0,
+        2.0,
+        2.0,
+        2.0
+      ],
+      "name": "Test-org-2",
+      "expenses_per_fte_month": "4000.00",
+      "days_per_week": 5,
+      "hours_per_day": "8.00",
+      "target_hourly_rate": "10.00",
+      "country": "DE",
+      "holiday_calendar": 2,
+      "site": 3
+    }
+  ]
+};
+
+export default {mockPowerheadResponse};
+

--- a/src/components/pages/PowerheadPage/view.js
+++ b/src/components/pages/PowerheadPage/view.js
@@ -251,19 +251,21 @@ function view(state$, monthSelectorVTree$, locationFilterVTree$) {
         reports = completeReports;
       }
 
-      return <div>
-        <div className={styles.contentWrapper}>
-          <h1>Powerhead</h1>
-          {monthSelectorVTree}
-          <div className={styles.filtersContainer}>
-            {locationFilterVTree}
+      return (
+        <div>
+          <div className={styles.contentWrapper}>
+            <h1>Powerhead</h1>
+            {monthSelectorVTree}
+            <div className={styles.filtersContainer}>
+              {locationFilterVTree}
+            </div>
           </div>
-        </div>
-        {reports.length === 0
-          ? renderLoadingIndicator()
-          : renderReports(reports)
-        }
-      </div>;
+          {reports.length === 0
+            ? renderLoadingIndicator()
+            : renderReports(reports)
+          }
+       </div>
+      );
     });
 }
 

--- a/src/conf.js
+++ b/src/conf.js
@@ -14,6 +14,11 @@
  * the License.
  */
 
+/* global GLOBAL */
+if (typeof GLOBAL !== 'undefined' && typeof GLOBAL['__DEV__'] === 'undefined') {
+  GLOBAL['__DEV__'] = true;
+}
+
 const LOCAL_HOST = 'http://localhost:8000';
 const PROD_HOST = 'https://power.futurice.com';
 


### PR DESCRIPTION
* Combines all tribes into single report for "show all"
* Makes people boxes smaller, if there are more than 52 to show.

New version will work to about 300 people boxes. After that we might need to make the boxes even smaller.
